### PR TITLE
adding --harmony-generators flag to test command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,4 @@ language: node_js
 node_js:
   - "node"
   - "iojs"
-script:
-  - "node --harmony-generators test/tape.js"
-  - "node test/tape.js"
+script: 'if [ "${TRAVIS_NODE_VERSION}" = "node" ]; then node --harmony-generators test/tape.js; else node test/tape.js ; fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,3 +2,6 @@ language: node_js
 node_js:
   - "node"
   - "iojs"
+script:
+  - "node --harmony-generators test/tape.js"
+  - "node test/tape.js"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "node test/tape.js | faucet && rm test/components -r"
+    "test": "node --harmony-generators test/tape.js | faucet && rm -r test/components"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is required for node 0.11+ (including 0.12) to work. (since duo uses generators under the hood for flow-control)